### PR TITLE
Bump internal version number displayed in XML file to the next relasease number

### DIFF
--- a/src/Z38/SwissPayment/Message/AbstractMessage.php
+++ b/src/Z38/SwissPayment/Message/AbstractMessage.php
@@ -82,7 +82,7 @@ abstract class AbstractMessage implements MessageInterface
      */
     public function getSoftwareVersion()
     {
-        return '0.7.0';
+        return '2.1.0';
     }
 
     /**


### PR DESCRIPTION
Today, the contact details is displaying the wrong library version number

![image](https://user-images.githubusercontent.com/646632/159499744-d1edd675-2296-448f-8d09-3bfcef30fe5b.png)

For traceability reasons, it is important to stick to the real release number