### PR TITLE
Add Notification Instruction

### DIFF
--- a/src/Z38/SwissPayment/PaymentInformation/NotificationInstruction.php
+++ b/src/Z38/SwissPayment/PaymentInformation/NotificationInstruction.php
@@ -34,7 +34,6 @@ class NotificationInstruction
     }
 
     /**
-     * @param string $instruction
      * @param bool $batchBooking
      * @return bool
      */

--- a/src/Z38/SwissPayment/PaymentInformation/NotificationInstruction.php
+++ b/src/Z38/SwissPayment/PaymentInformation/NotificationInstruction.php
@@ -34,6 +34,22 @@ class NotificationInstruction
     }
 
     /**
+     * @param string $instruction
+     * @param bool $batchBooking
+     * @return bool
+     */
+    public function checkAgainstBatchBooking($batchBooking)
+    {
+        if ($batchBooking === false && !in_array($this->instruction, ['NOA', 'SIA'], true)) {
+            return false;
+        }
+        if ($batchBooking === true && !in_array($this->instruction, ['NOA', 'CND', 'CWD'], true)) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Returns an XML representation of this purpose
      *
      * @param DOMDocument $doc

--- a/src/Z38/SwissPayment/PaymentInformation/NotificationInstruction.php
+++ b/src/Z38/SwissPayment/PaymentInformation/NotificationInstruction.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Z38\SwissPayment\PaymentInformation;
+
+use DOMDocument;
+use DOMElement;
+use InvalidArgumentException;
+
+/**
+ * NotificationInstruction contains the instruction to control the debit advice
+ */
+class NotificationInstruction
+{
+    /**
+     * @var string
+     */
+    protected $instruction;
+
+    /**
+     * Constructor
+     *
+     * @param string $instruction
+     *
+     * @throws InvalidArgumentException When the code is not valid
+     */
+    public function __construct($instruction)
+    {
+        $instruction = (string)$instruction;
+        if (!in_array($instruction, ['NOA', 'SIA', 'CND', 'CWD'], true)) {
+            throw new InvalidArgumentException('The notification instruction is not valid. It must be one of the following: NOA, SIA, CND or CWD');
+        }
+
+        $this->instruction = $instruction;
+    }
+
+    /**
+     * Returns an XML representation of this purpose
+     *
+     * @param DOMDocument $doc
+     *
+     * @return DOMElement The built DOM element
+     */
+    public function asDom(DOMDocument $doc)
+    {
+        return $doc->createElement('Prtry', $this->instruction);
+    }
+}

--- a/src/Z38/SwissPayment/PaymentInformation/PaymentInformation.php
+++ b/src/Z38/SwissPayment/PaymentInformation/PaymentInformation.php
@@ -71,6 +71,11 @@ class PaymentInformation
     protected $debtorIBAN;
 
     /**
+     * @var NotificationInstruction|null
+     */
+    protected $notificationInstruction;
+
+    /**
      * Constructor
      *
      * @param string  $id          Identifier of this group (should be unique within a message)
@@ -210,6 +215,21 @@ class PaymentInformation
     }
 
     /**
+     * Sets the notification Instruction
+     * Can be used to control the debit advice
+     *
+     * @param NotificationInstruction $notificationInstruction
+     *
+     * @return PaymentInformation This payment instruction
+     */
+    public function setNotificationInstruction($notificationInstruction)
+    {
+        $this->notificationInstruction = $notificationInstruction;
+
+        return $this;
+    }
+
+    /**
      * Builds a DOM tree of this payment instruction
      *
      * @param DOMDocument $doc
@@ -259,6 +279,11 @@ class PaymentInformation
         $debtorAccountId = $doc->createElement('Id');
         $debtorAccountId->appendChild($doc->createElement('IBAN', $this->debtorIBAN->normalize()));
         $debtorAccount->appendChild($debtorAccountId);
+        if ($this->notificationInstruction) {
+            $debtorAccountTp = $doc->createElement('Tp');
+            $debtorAccountTp->appendChild($this->notificationInstruction->asDom($doc));
+            $debtorAccount->appendChild($debtorAccountTp);
+        }
         $root->appendChild($debtorAccount);
 
         $debtorAgent = $doc->createElement('DbtrAgt');

--- a/src/Z38/SwissPayment/PaymentInformation/PaymentInformation.php
+++ b/src/Z38/SwissPayment/PaymentInformation/PaymentInformation.php
@@ -165,6 +165,10 @@ class PaymentInformation
      */
     public function setBatchBooking($batchBooking)
     {
+        if ($this->notificationInstruction && !$this->notificationInstruction->checkAgainstBatchBooking($batchBooking)) {
+            throw new InvalidArgumentException('Batch booking cannot be used with the current Notification Instruction');
+        }
+
         $this->batchBooking = boolval($batchBooking);
 
         return $this;
@@ -224,6 +228,9 @@ class PaymentInformation
      */
     public function setNotificationInstruction($notificationInstruction)
     {
+        if (!$notificationInstruction->checkAgainstBatchBooking($this->batchBooking)) {
+            throw new InvalidArgumentException('Notification instruction cannot be used with the current batch booking');
+        }
         $this->notificationInstruction = $notificationInstruction;
 
         return $this;

--- a/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
+++ b/tests/Z38/SwissPayment/Tests/Message/CustomerCreditTransferTest.php
@@ -13,6 +13,7 @@ use Z38\SwissPayment\ISRParticipant;
 use Z38\SwissPayment\Message\CustomerCreditTransfer;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\CategoryPurposeCode;
+use Z38\SwissPayment\PaymentInformation\NotificationInstruction;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
 use Z38\SwissPayment\PaymentInformation\SEPAPaymentInformation;
 use Z38\SwissPayment\PostalAccount;
@@ -229,6 +230,7 @@ class CustomerCreditTransferTest extends TestCase
             new BIC('ZKBKCHZZ80A'),
             new IBAN('CH6600700110000204481')
         );
+        $payment->setNotificationInstruction(new NotificationInstruction('CWD'));
         $message->addPayment($payment);
 
         $qrIban = new IBAN('CH44 3199 9123 0008 8901 2');

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/NotificationInstructionTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/NotificationInstructionTest.php
@@ -71,4 +71,51 @@ class NotificationInstructionTest extends TestCase
         self::assertSame('Prtry', $xml->nodeName);
         self::assertSame('CWD', $xml->textContent);
     }
+
+    /**
+     * @dataProvider invalidCheckAgainstBatchBooking
+     * @covers ::checkAgainstBatchBooking
+     */
+    public function testInvalidCheckAgainstBatchBooking($instruction, $batchBooking)
+    {
+        $notificationInstruction = new NotificationInstruction($instruction);
+        self::assertFalse($notificationInstruction->checkAgainstBatchBooking($batchBooking));
+    }
+
+    /**
+     * @dataProvider validCheckAgainstBatchBooking
+     * @covers ::checkAgainstBatchBooking
+     */
+    public function testCheckAgainstBatchBooking($instruction, $batchBooking)
+    {
+        $notificationInstruction = new NotificationInstruction($instruction);
+        self::assertTrue($notificationInstruction->checkAgainstBatchBooking($batchBooking));
+    }
+
+    /**
+     * @return array[]
+     */
+    public function invalidCheckAgainstBatchBooking()
+    {
+        return [
+            ['CWD', false],
+            ['CND', false],
+            ['SIA', true],
+        ];
+    }
+
+    /**
+     * @return array[]
+     */
+    public function validCheckAgainstBatchBooking()
+    {
+        return [
+            ['NOA', false],
+            ['SIA', false],
+            ['NOA', true],
+            ['CND', true],
+            ['CWD', true],
+        ];
+    }
+
 }

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/NotificationInstructionTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/NotificationInstructionTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Z38\SwissPayment\Tests\PaymentInformation;
+
+use DOMDocument;
+use InvalidArgumentException;
+use Z38\SwissPayment\PaymentInformation\NotificationInstruction;
+use Z38\SwissPayment\Tests\TestCase;
+
+/**
+ * @coversDefaultClass \Z38\SwissPayment\PaymentInformation\NotificationInstruction
+ */
+class NotificationInstructionTest extends TestCase
+{
+    /**
+     * @dataProvider validSamples
+     * @covers ::__construct
+     */
+    public function testValid($instruction)
+    {
+        self::assertInstanceOf('Z38\SwissPayment\PaymentInformation\NotificationInstruction', new NotificationInstruction($instruction));
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function validSamples()
+    {
+        return [
+            ['NOA'], // No Advice
+            ['SIA'], // Single Advice
+            ['CND'], // Collective Advice No Details
+            ['CWD'], // Collective Advice With Details
+        ];
+    }
+
+    /**
+     * @dataProvider invalidSamples
+     * @covers ::__construct
+     */
+    public function testInvalid($instruction)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new NotificationInstruction($instruction);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function invalidSamples()
+    {
+        return [
+            [''],
+            ['noa'],
+            ['something-else'],
+            [' CWD'],
+            ['CWD '],
+        ];
+    }
+
+    /**
+     * @covers ::asDom
+     */
+    public function testAsDom()
+    {
+        $doc = new DOMDocument();
+        $iid = new NotificationInstruction('CWD');
+
+        $xml = $iid->asDom($doc);
+
+        self::assertSame('Prtry', $xml->nodeName);
+        self::assertSame('CWD', $xml->textContent);
+    }
+}

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/PaymentInformationTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/PaymentInformationTest.php
@@ -10,6 +10,7 @@ use Z38\SwissPayment\FinancialInstitutionInterface;
 use Z38\SwissPayment\IBAN;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\CategoryPurposeCode;
+use Z38\SwissPayment\PaymentInformation\NotificationInstruction;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
 use Z38\SwissPayment\PostalAccount;
 use Z38\SwissPayment\StructuredPostalAddress;
@@ -90,4 +91,25 @@ class PaymentInformationTest extends TestCase
         self::assertSame('CH02', $xpath->evaluate('string(./PmtTpInf/LclInstrm/Prtry)', $xml));
         self::assertSame(0.0, $xpath->evaluate('count(./CdtTrfTxInf/PmtTpInf/LclInstrm/Prtry)', $xml));
     }
+
+    /**
+     * @covers ::asDom
+     */
+    public function testNotificationInstruction()
+    {
+        $doc = new DOMDocument();
+        $payment = new PaymentInformation(
+            'id000',
+            'name',
+            new BIC('POFICHBEXXX'),
+            new IBAN('CH31 8123 9000 0012 4568 9')
+        );
+        $payment->setNotificationInstruction(new NotificationInstruction('CWD'));
+
+        $xml = $payment->asDom($doc);
+        $xpath = new DOMXPath($doc);
+
+        self::assertSame('CWD', $xpath->evaluate('string(./DbtrAcct/Tp/Prtry)', $xml));
+    }
+
 }

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/PaymentInformationTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/PaymentInformationTest.php
@@ -112,4 +112,43 @@ class PaymentInformationTest extends TestCase
         self::assertSame('CWD', $xpath->evaluate('string(./DbtrAcct/Tp/Prtry)', $xml));
     }
 
+    /**
+     * @covers ::setNotificationInstruction
+     */
+    public function testInvalidNotificationInstruction()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $payment = new PaymentInformation(
+            'id000',
+            'name',
+            new BIC('POFICHBEXXX'),
+            new IBAN('CH31 8123 9000 0012 4568 9')
+        );
+
+        $payment
+            ->setBatchBooking(false)
+            ->setNotificationInstruction(new NotificationInstruction('CWD'));
+    }
+
+    /**
+     * @covers ::setBatchBooking
+     */
+    public function testInvalidBatchBooking()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $payment = new PaymentInformation(
+            'id000',
+            'name',
+            new BIC('POFICHBEXXX'),
+            new IBAN('CH31 8123 9000 0012 4568 9')
+        );
+
+        $payment
+            ->setNotificationInstruction(new NotificationInstruction('CWD'))
+            ->setBatchBooking(false);
+    }
+
+
 }


### PR DESCRIPTION
## Motivation
For some banks, such as BCV, not indicating anything in the Notification Instruction in combination with the Batch Booking value set to `true` is processed by the bank with a global debit notification **without details**.  
In result, the **camt.053** file does not include the `EndToEndId`.

If we want to receive the details of all the transactions from our payment in the **camt.053** file and at the same time have a single grouped entry on our account statement, our XML has to contain `CWD` in the Notification Instruction.

This pull request adds the Notification Instruction based on six-group implementation guideline[^1] and tests.

## Usage
```php
$payment = new PaymentInformation(
    'payment-001',
    'InnoMuster AG',
    new BIC('ZKBKCHZZ80A'),
    new IBAN('CH6600700110000204481')
);

/**
 * Available types: 
 *            NOA - No Advice
 *            SIA - Single Advice
 *            CND - Collective Advice No Details
 *            CWD - Collective Advice With Details 
 */
$payment->setNotificationInstruction(new NotificationInstruction('CWD'));
```


## Notes

- When used, this instruction should not be used with`PmtInf/DbtrAcct/Tp/Code` at the same time. The library doesn't support `Code` at the moment so it shouldn't be an issue
- It was already implemented in the [validation schema](https://github.com/ch2877/swiss-payment/blob/master/tests/pain.001.001.03.ch.02.xsd#L174)
- This is _optional_ and shouldn't be a BC
- Some types are not compatible with the batch booking when set to false/true, this PR include a validation based on the Swiss Business Rules[^2]
- The name **Notification Instruction** has been choose as it's referred as such in the implementation guideline. _[...] notification instruction CND/NOA results in a confidential payment_. I realized later that it seems to be more used with the term _Debit Advice_. I would be happy to rename to **Debit Advice** if this is preferred. 

## References
[^1]: Implementation guideline: https://www.six-group.com/dam/download/banking-services/interbank-clearing/en/standardization/iso/swiss-recommendations/implementation-guidelines-ct.pdf#page=31
[^2]: Swiss Business Rule: https://www.six-group.com/dam/download/banking-services/interbank-clearing/en/standardization/iso/swiss-recommendations/business-rules.pdf#page=48
