### PR TITLE
Support SPS-2022

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['8.1', '8.2', '8.3', '8.4']
         stability: ['prefer-stable']
       fail-fast: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,15 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
-        stability: ['prefer-lowest', 'prefer-stable']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        stability: ['prefer-stable']
       fail-fast: false
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -31,7 +31,7 @@ jobs:
         run: find ./ -type f -name '*.php' -print0 | xargs -0 -L1 -P4 -- php -l
 
       - name: Check composer files
-        run:  composer validate --strict
+        run: composer validate --strict
 
       - name: Install dependencies
         run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SwissPayment Changelog
 
+## 3.0.0 (2023-10-02)
+
+  * SPS 2022 compatibility
+
 ## 2.0.0 (2021-10-19)
 
   * Added support for QR Bills (BankCreditTransferWithCreditorReference, BankCreditTransferWithQRR)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ require_once __DIR__.'/vendor/autoload.php';
 
 use Z38\SwissPayment\BIC;
 use Z38\SwissPayment\IBAN;
-use Z38\SwissPayment\Message\CustomerCreditTransfer;
+use Z38\SwissPayment\Message\AbstractCustomerCreditTransfer;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
 use Z38\SwissPayment\PostalAccount;
@@ -39,15 +39,31 @@ $transaction1 = new BankCreditTransfer(
     new BIC('UBSWCHZH80A')
 );
 
-$transaction2 = new IS1CreditTransfer(
+$transaction2 = new BankCreditTransferWithCreditorReference(
     'instr-002',
     'e2e-002',
-    new Money\CHF(30000), // CHF 300.00
-    'Finanzverwaltung Stadt Musterhausen',
-    UnstructuredPostalAddress::sanitize('Altstadt 1a', '4998 Musterhausen'),
-    new PostalAccount('80-151-4')
+    new Money\CHF(130000), // CHF 1300.00
+    'Muster Transport AG',
+    new StructuredPostalAddress('Wiesenweg', '14b', '8058', 'Zürich-Flughafen'),
+    $iban,
+    IID::fromIBAN($iban),
+    'RF 72 0191 2301 0040 5JSH 0438'
 );
+$transaction->setRemittanceInformation("Test Remittance");
 
+$qrIban = new IBAN('CH44 3199 9123 0008 8901 2');
+$transaction3 = new BankCreditTransferWithQRR(
+    'instr-003',
+    'e2e-003',
+    new Money\CHF(130000), // CHF 1300.00
+    'Muster Transport AG',
+    new StructuredPostalAddress('Wiesenweg', '14b', '8058', 'Zürich-Flughafen'),
+    $qrIban,
+    IID::fromIBAN($qrIban),
+    '210000000003139471430009017'
+);
+$transaction->setRemittanceInformation("Test Remittance");
+        
 $payment = new PaymentInformation(
     'payment-001',
     'InnoMuster AG',
@@ -56,8 +72,9 @@ $payment = new PaymentInformation(
 );
 $payment->addTransaction($transaction1);
 $payment->addTransaction($transaction2);
+$payment->addTransaction($transaction3);
 
-$message = new CustomerCreditTransfer('message-001', 'InnoMuster AG');
+$message = new CustomerCreditTransfer('message-001', 'InnoMuster AG', CustomerCreditTransfer::SPS_2022, 'softwareName', 'version', 'manufacturerName');
 $message->addPayment($payment);
 
 echo $message->asXml();

--- a/src/Z38/SwissPayment/BIC.php
+++ b/src/Z38/SwissPayment/BIC.php
@@ -4,6 +4,7 @@ namespace Z38\SwissPayment;
 
 use DOMDocument;
 use InvalidArgumentException;
+use Z38\SwissPayment\Message\CustomerCreditTransfer;
 
 /**
  * BIC
@@ -46,10 +47,14 @@ class BIC implements FinancialInstitutionInterface
     /**
      * {@inheritdoc}
      */
-    public function asDom(DOMDocument $doc)
+    public function asDom(DOMDocument $doc, string $spsVersion)
     {
         $xml = $doc->createElement('FinInstnId');
-        $xml->appendChild($doc->createElement('BIC', $this->format()));
+        if ($spsVersion === CustomerCreditTransfer::SPS_2021) {
+            $xml->appendChild($doc->createElement('BIC', $this->format()));
+        } else {
+            $xml->appendChild($doc->createElement('BICFI', $this->format()));
+        }
 
         return $xml;
     }

--- a/src/Z38/SwissPayment/FinancialInstitutionAddress.php
+++ b/src/Z38/SwissPayment/FinancialInstitutionAddress.php
@@ -37,8 +37,10 @@ class FinancialInstitutionAddress implements FinancialInstitutionInterface
     /**
      * {@inheritdoc}
      */
-    public function asDom(DOMDocument $doc)
+    public function asDom(DOMDocument $doc, string $spsVersion)
     {
+        unset($spsVersion);
+
         $xml = $doc->createElement('FinInstnId');
         $xml->appendChild(Text::xml($doc, 'Nm', $this->name));
         $xml->appendChild($this->address->asDom($doc));

--- a/src/Z38/SwissPayment/FinancialInstitutionInterface.php
+++ b/src/Z38/SwissPayment/FinancialInstitutionInterface.php
@@ -14,8 +14,8 @@ interface FinancialInstitutionInterface
      * Returns an XML representation to identify the financial institution
      *
      * @param DOMDocument $doc
-     *
+     * @param string $spsVersion
      * @return DOMElement The built DOM element
      */
-    public function asDom(DOMDocument $doc);
+    public function asDom(DOMDocument $doc, string $spsVersion);
 }

--- a/src/Z38/SwissPayment/IID.php
+++ b/src/Z38/SwissPayment/IID.php
@@ -61,8 +61,10 @@ class IID implements FinancialInstitutionInterface
     /**
      * {@inheritdoc}
      */
-    public function asDom(DOMDocument $doc)
+    public function asDom(DOMDocument $doc, string $spsVersion)
     {
+        unset($spsVersion);
+
         $xml = $doc->createElement('FinInstnId');
         $clearingSystem = $doc->createElement('ClrSysMmbId');
         $clearingSystemId = $doc->createElement('ClrSysId');

--- a/src/Z38/SwissPayment/Message/AbstractMessage.php
+++ b/src/Z38/SwissPayment/Message/AbstractMessage.php
@@ -4,7 +4,6 @@ namespace Z38\SwissPayment\Message;
 
 use DOMDocument;
 use DOMElement;
-use Z38\SwissPayment\Text;
 
 /**
  * AbstractMessages eases message creation using DOM
@@ -25,14 +24,14 @@ abstract class AbstractMessage implements MessageInterface
      *
      * @return string
      */
-    abstract protected function getSchemaName();
+    abstract public function getSchemaName();
 
     /**
      * Gets the location of the schema
      *
      * @return string|null The location or null
      */
-    abstract protected function getSchemaLocation();
+    abstract public function getSchemaLocation();
 
     /**
      * Builds a DOM document of the message
@@ -63,42 +62,5 @@ abstract class AbstractMessage implements MessageInterface
     public function asXml()
     {
         return $this->asDom()->saveXML();
-    }
-
-    /**
-     * Returns the name of the software used to create the message
-     *
-     * @return string
-     */
-    public function getSoftwareName()
-    {
-        return 'Z38_SwissPayment';
-    }
-
-    /**
-     * Returns the version of the software used to create the message
-     *
-     * @return string
-     */
-    public function getSoftwareVersion()
-    {
-        return '0.7.0';
-    }
-
-    /**
-     * Creates a DOM element which contains details about the software used to create the message
-     *
-     * @param DOMDocument $doc
-     *
-     * @return DOMElement
-     */
-    protected function buildContactDetails(DOMDocument $doc)
-    {
-        $root = $doc->createElement('CtctDtls');
-
-        $root->appendChild(Text::xml($doc, 'Nm', $this->getSoftwareName()));
-        $root->appendChild(Text::xml($doc, 'Othr', $this->getSoftwareVersion()));
-
-        return $root;
     }
 }

--- a/src/Z38/SwissPayment/Message/CustomerCreditTransfer.php
+++ b/src/Z38/SwissPayment/Message/CustomerCreditTransfer.php
@@ -4,6 +4,7 @@ namespace Z38\SwissPayment\Message;
 
 use DateTime;
 use DOMDocument;
+use DOMElement;
 use InvalidArgumentException;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
@@ -14,6 +15,10 @@ use Z38\SwissPayment\Text;
  */
 class CustomerCreditTransfer extends AbstractMessage
 {
+    // SPS-2021 version is supported until November 2024
+    public const SPS_2021 = 'SPS-2021';
+    public const SPS_2022 = 'SPS-2022';
+
     /**
      * @var string
      */
@@ -35,6 +40,26 @@ class CustomerCreditTransfer extends AbstractMessage
     protected $creationTime;
 
     /**
+     * @var string
+     */
+    protected $spsVersion;
+
+    /**
+     * @var string
+     */
+    protected $softwareName;
+
+    /**
+     * @var string
+     */
+    protected $softwareVersion;
+
+    /**
+     * @var string
+     */
+    protected $manufacturerName;
+
+    /**
      * Constructor
      *
      * @param string $id              Identifier of the message (should usually be unique over a period of at least 90 days)
@@ -42,12 +67,16 @@ class CustomerCreditTransfer extends AbstractMessage
      *
      * @throws InvalidArgumentException When any of the inputs contain invalid characters or are too long.
      */
-    public function __construct($id, $initiatingParty)
+    public function __construct($id, $initiatingParty, $spsVersion = self::SPS_2021, $softwareName = null, $softwareVersion = null, $manufacturerName = null)
     {
         $this->id = Text::assertIdentifier($id);
         $this->initiatingParty = Text::assert($initiatingParty, 70);
         $this->payments = [];
         $this->creationTime = new DateTime();
+        $this->spsVersion = $spsVersion;
+        $this->softwareName = $softwareName;
+        $this->softwareVersion = $softwareVersion;
+        $this->manufacturerName = $manufacturerName;
     }
 
     /**
@@ -89,19 +118,109 @@ class CustomerCreditTransfer extends AbstractMessage
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the name of the software used to create the message
+     *
+     * @return string
      */
-    protected function getSchemaName()
+    public function getSoftwareName()
     {
-        return 'http://www.six-interbank-clearing.com/de/pain.001.001.03.ch.02.xsd';
+        return $this->softwareName;
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the version of the software used to create the message
+     *
+     * @return string
      */
-    protected function getSchemaLocation()
+    public function getSoftwareVersion()
     {
-        return 'pain.001.001.03.ch.02.xsd';
+        return $this->softwareVersion;
+    }
+
+    /**
+     * Returns the sps version used to create the message
+     *
+     * @return string
+     */
+    public function getSpsVersion()
+    {
+        return $this->spsVersion;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSchemaName()
+    {
+        if ($this->spsVersion === self::SPS_2021){
+            return 'http://www.six-interbank-clearing.com/de/pain.001.001.03.ch.02.xsd';
+        } else {
+            return 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.09';
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getSchemaLocation()
+    {
+        if ($this->spsVersion === self::SPS_2021){
+            return 'pain.001.001.03.ch.02.xsd';
+        } else {
+            return 'pain.001.001.09.ch.03.xsd';
+        }
+    }
+
+    /**
+     * Creates a DOM element which contains details about the software used to create the message
+     *
+     * @param DOMDocument $doc
+     *
+     * @return ?DOMElement
+     */
+    private function buildContactDetails(DOMDocument $doc)
+    {
+        // Software name is mandatory to build the contact details
+        if (empty($this->softwareName)) {
+            return null;
+        }
+
+        $root = $doc->createElement('CtctDtls');
+
+        if ($this->spsVersion === self::SPS_2021) {
+            $root->appendChild(Text::xml($doc, 'Nm', $this->softwareName));
+            if (empty($this->softwareVersion) === false) {
+                $root->appendChild(Text::xml($doc, 'Othr', $this->softwareVersion));
+            }
+        } else {
+            if (empty($this->softwareName) === false) {
+                $otherProductName = $doc->createElement('Othr');
+                $otherProductName->appendChild($doc->createElement('ChanlTp', 'NAME'));
+                $otherProductName->appendChild($doc->createElement('Id', $this->softwareName));
+                $root->appendChild($otherProductName);
+            }
+
+            if (empty($this->softwareVersion) === false) {
+                $otherSoftwareVersion = $doc->createElement('Othr');
+                $otherSoftwareVersion->appendChild($doc->createElement('ChanlTp', 'VRSN'));
+                $otherSoftwareVersion->appendChild($doc->createElement('Id', $this->softwareVersion));
+                $root->appendChild($otherSoftwareVersion);
+            }
+
+            if (empty($this->manufacturerName) === false) {
+                $otherManufacturerName = $doc->createElement('Othr');
+                $otherManufacturerName->appendChild($doc->createElement('ChanlTp', 'PRVD'));
+                $otherManufacturerName->appendChild($doc->createElement('Id', $this->manufacturerName));
+                $root->appendChild($otherManufacturerName);
+            }
+
+            $otherSpsIgVersion = $doc->createElement('Othr');
+            $otherSpsIgVersion->appendChild($doc->createElement('ChanlTp', 'SPSV'));
+            $otherSpsIgVersion->appendChild($doc->createElement('Id', '0200'));
+            $root->appendChild($otherSpsIgVersion);
+        }
+
+        return $root;
     }
 
     /**
@@ -124,12 +243,15 @@ class CustomerCreditTransfer extends AbstractMessage
         $header->appendChild(Text::xml($doc, 'CtrlSum', $transactionSum->format()));
         $initgParty = $doc->createElement('InitgPty');
         $initgParty->appendChild(Text::xml($doc, 'Nm', $this->initiatingParty));
-        $initgParty->appendChild($this->buildContactDetails($doc));
+        $contactDetails = $this->buildContactDetails($doc);
+        if (isset($contactDetails)) {
+            $initgParty->appendChild($contactDetails);
+        }
         $header->appendChild($initgParty);
         $root->appendChild($header);
 
         foreach ($this->payments as $payment) {
-            $root->appendChild($payment->asDom($doc));
+            $root->appendChild($payment->asDom($doc, $this->spsVersion));
         }
 
         return $root;

--- a/src/Z38/SwissPayment/Text.php
+++ b/src/Z38/SwissPayment/Text.php
@@ -12,7 +12,7 @@ use InvalidArgumentException;
  */
 class Text
 {
-    private const TEXT_NON_CH = '/[^A-Za-z0-9 .,:\'\/()?+\-!"#%&*;<>÷=@_$£[\]{}\` ́~àáâäçèéêëìíîïñòóôöùúûüýßÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÑ]+/u';
+    private const TEXT_NON_CH = '/[^A-Za-z0-9 .,:\'\/()?+\-!"#%&*;<>÷=@_$£[\]{}\` ́~àáâäçèéêëìíîïñòóôöùúûüýßÀÁÂÄÇÈÉÊËÌÍÎÏÒÓÔÖÙÚÛÜÑ€ȘșȚț]+/u';
     private const TEXT_NON_SWIFT = '/[^A-Za-z0-9 .,:\'\/()?+\-]+/';
 
     /**

--- a/src/Z38/SwissPayment/TransactionInformation/BankCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/BankCreditTransfer.php
@@ -56,12 +56,12 @@ class BankCreditTransfer extends CreditTransfer
     /**
      * {@inheritdoc}
      */
-    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation)
+    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation, string $spsVersion)
     {
         $root = $this->buildHeader($doc, $paymentInformation);
 
         $creditorAgent = $doc->createElement('CdtrAgt');
-        $creditorAgent->appendChild($this->creditorAgent->asDom($doc));
+        $creditorAgent->appendChild($this->creditorAgent->asDom($doc, $spsVersion));
         $root->appendChild($creditorAgent);
 
         $root->appendChild($this->buildCreditor($doc));

--- a/src/Z38/SwissPayment/TransactionInformation/CreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/CreditTransfer.php
@@ -144,12 +144,12 @@ abstract class CreditTransfer
     /**
      * Builds a DOM tree of this transaction
      *
-     * @param DOMDocument       $doc
+     * @param DOMDocument $doc
      * @param PaymentInformation $paymentInformation Information on B-level
-     *
+     * @param string $spsVersion
      * @return DOMElement The built DOM tree
      */
-    abstract public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation);
+    abstract public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation, string $spsVersion);
 
     /**
      * Builds a DOM tree of this transaction and adds header nodes

--- a/src/Z38/SwissPayment/TransactionInformation/ForeignCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/ForeignCreditTransfer.php
@@ -62,18 +62,18 @@ class ForeignCreditTransfer extends CreditTransfer
     /**
      * {@inheritdoc}
      */
-    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation)
+    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation, $spsVersion)
     {
         $root = $this->buildHeader($doc, $paymentInformation);
 
         if ($this->intermediaryAgent !== null) {
             $intermediaryAgent = $doc->createElement('IntrmyAgt1');
-            $intermediaryAgent->appendChild($this->intermediaryAgent->asDom($doc));
+            $intermediaryAgent->appendChild($this->intermediaryAgent->asDom($doc, $spsVersion));
             $root->appendChild($intermediaryAgent);
         }
 
         $creditorAgent = $doc->createElement('CdtrAgt');
-        $creditorAgent->appendChild($this->creditorAgent->asDom($doc));
+        $creditorAgent->appendChild($this->creditorAgent->asDom($doc, $spsVersion));
         $root->appendChild($creditorAgent);
 
         $root->appendChild($this->buildCreditor($doc));

--- a/src/Z38/SwissPayment/TransactionInformation/IS1CreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/IS1CreditTransfer.php
@@ -4,6 +4,8 @@ namespace Z38\SwissPayment\TransactionInformation;
 
 use DOMDocument;
 use InvalidArgumentException;
+use LogicException;
+use Z38\SwissPayment\Message\CustomerCreditTransfer;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
 use Z38\SwissPayment\PostalAccount;
@@ -43,8 +45,12 @@ class IS1CreditTransfer extends CreditTransfer
     /**
      * {@inheritdoc}
      */
-    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation)
+    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation, string $spsVersion)
     {
+        if ($spsVersion !== CustomerCreditTransfer::SPS_2021) {
+            throw new LogicException('IS 2-stage payments can only be created until SPS 2021 version');
+        }
+
         $root = $this->buildHeader($doc, $paymentInformation);
 
         $root->appendChild($this->buildCreditor($doc));

--- a/src/Z38/SwissPayment/TransactionInformation/IS2CreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/IS2CreditTransfer.php
@@ -4,7 +4,9 @@ namespace Z38\SwissPayment\TransactionInformation;
 
 use DOMDocument;
 use InvalidArgumentException;
+use LogicException;
 use Z38\SwissPayment\IBAN;
+use Z38\SwissPayment\Message\CustomerCreditTransfer;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
 use Z38\SwissPayment\PostalAccount;
@@ -59,8 +61,12 @@ class IS2CreditTransfer extends CreditTransfer
     /**
      * {@inheritdoc}
      */
-    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation)
+    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation, string $spsVersion)
     {
+        if ($spsVersion !== CustomerCreditTransfer::SPS_2021) {
+            throw new LogicException('IS 2-stage payments can only be created until SPS 2021 version');
+        }
+
         $root = $this->buildHeader($doc, $paymentInformation);
 
         $creditorAgent = $doc->createElement('CdtrAgt');

--- a/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/ISRCreditTransfer.php
@@ -7,6 +7,7 @@ use DOMElement;
 use InvalidArgumentException;
 use LogicException;
 use Z38\SwissPayment\ISRParticipant;
+use Z38\SwissPayment\Message\CustomerCreditTransfer;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\PaymentInformation;
 use Z38\SwissPayment\PostalAccount;
@@ -35,6 +36,7 @@ class ISRCreditTransfer extends CreditTransfer
      * @param string         $creditorReference ISR reference number
      *
      * @throws InvalidArgumentException When the amount or the creditor reference is invalid.
+     * @noinspection PhpMissingParentConstructorInspection
      */
     public function __construct($instructionId, $endToEndId, Money\Money $amount, ISRParticipant $creditorAccount, $creditorReference)
     {
@@ -80,8 +82,12 @@ class ISRCreditTransfer extends CreditTransfer
     /**
      * {@inheritdoc}
      */
-    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation)
+    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation, string $spsVersion)
     {
+        if ($spsVersion !== CustomerCreditTransfer::SPS_2021) {
+            throw new LogicException('ISR payments can only be created until SPS 2021 version');
+        }
+
         $root = $this->buildHeader($doc, $paymentInformation);
 
         if (strlen($this->creditorName) && isset($this->creditorAddress)) {

--- a/src/Z38/SwissPayment/TransactionInformation/SEPACreditTransfer.php
+++ b/src/Z38/SwissPayment/TransactionInformation/SEPACreditTransfer.php
@@ -45,7 +45,7 @@ class SEPACreditTransfer extends CreditTransfer
     /**
      * {@inheritdoc}
      */
-    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation)
+    public function asDom(DOMDocument $doc, PaymentInformation $paymentInformation, string $spsVersion)
     {
         $root = $this->buildHeader($doc, $paymentInformation);
 
@@ -53,7 +53,7 @@ class SEPACreditTransfer extends CreditTransfer
 
         if ($this->creditorAgentBIC !== null) {
             $creditorAgent = $doc->createElement('CdtrAgt');
-            $creditorAgent->appendChild($this->creditorAgentBIC->asDom($doc));
+            $creditorAgent->appendChild($this->creditorAgentBIC->asDom($doc, $spsVersion));
             $root->appendChild($creditorAgent);
         }
 

--- a/tests/Z38/SwissPayment/Tests/IIDTest.php
+++ b/tests/Z38/SwissPayment/Tests/IIDTest.php
@@ -7,6 +7,7 @@ use DOMXPath;
 use InvalidArgumentException;
 use Z38\SwissPayment\IBAN;
 use Z38\SwissPayment\IID;
+use Z38\SwissPayment\Message\CustomerCreditTransfer;
 
 /**
  * @coversDefaultClass \Z38\SwissPayment\IID
@@ -104,7 +105,7 @@ class IIDTest extends TestCase
         $doc = new DOMDocument();
         $iid = new IID('09000');
 
-        $xml = $iid->asDom($doc);
+        $xml = $iid->asDom($doc, CustomerCreditTransfer::SPS_2022);
 
         $xpath = new DOMXPath($doc);
         $this->assertSame('9000', $xpath->evaluate('string(.//MmbId)', $xml));

--- a/tests/Z38/SwissPayment/Tests/PaymentInformation/SEPAPaymentInformationTest.php
+++ b/tests/Z38/SwissPayment/Tests/PaymentInformation/SEPAPaymentInformationTest.php
@@ -7,6 +7,7 @@ use DOMXPath;
 use LogicException;
 use Z38\SwissPayment\BIC;
 use Z38\SwissPayment\IBAN;
+use Z38\SwissPayment\Message\CustomerCreditTransfer;
 use Z38\SwissPayment\Money;
 use Z38\SwissPayment\PaymentInformation\SEPAPaymentInformation;
 use Z38\SwissPayment\StructuredPostalAddress;
@@ -57,7 +58,7 @@ class SEPAPaymentInformationTest extends TestCase
         ));
 
         $doc = new DOMDocument();
-        $dom = $payment->asDom($doc);
+        $dom = $payment->asDom($doc, CustomerCreditTransfer::SPS_2022);
         $doc->appendChild($dom);
 
         $xpath = new DOMXPath($doc);
@@ -89,6 +90,6 @@ class SEPAPaymentInformationTest extends TestCase
         ));
 
         $doc = new DOMDocument();
-        $payment->asDom($doc);
+        $payment->asDom($doc, CustomerCreditTransfer::SPS_2022);
     }
 }

--- a/tests/pain.001.001.09.ch.03.xsd
+++ b/tests/pain.001.001.09.ch.03.xsd
@@ -1,0 +1,1735 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+(C) Copyright 2021, SIX, www.iso-payments.ch
+CH Version for pain.001 Credit Transfer: "pain.001.001.09.ch.03.xsd"
+.ch.:	            Identification for this CH version
+Last part (.03):   CH Version of this scheme
+
+Based on ISO pain.001.001.09 (urn:iso:std:iso:20022:tech:xsd:pain.001.001.09)
+-->
+<xs:schema xmlns="urn:iso:std:iso:20022:tech:xsd:pain.001.001.09" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="urn:iso:std:iso:20022:tech:xsd:pain.001.001.09" elementFormDefault="qualified">
+	<xs:element name="Document" type="Document_pain001_ch"/>
+	<xs:complexType name="AccountIdentification4Choice">
+		<xs:choice>
+			<xs:element name="IBAN" type="IBAN2007Identifier"/>
+			<xs:element name="Othr" type="GenericAccountIdentification1"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="AccountIdentification4Choice_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="AccountIdentification4Choice">
+				<xs:choice>
+					<xs:element name="IBAN" type="IBAN2007Identifier"/>
+					<xs:element name="Othr" type="GenericAccountIdentification1_pain001_ch"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="AccountSchemeName1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalAccountIdentification1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ActiveOrHistoricCurrencyAndAmount">
+		<xs:simpleContent>
+			<xs:extension base="ActiveOrHistoricCurrencyAndAmount_SimpleType">
+				<xs:attribute name="Ccy" type="ActiveOrHistoricCurrencyCode" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyAndAmount_SimpleType">
+		<xs:restriction base="xs:decimal">
+			<xs:minInclusive value="0"/>
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="5"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ActiveOrHistoricCurrencyCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{3,3}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="AddressType2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ADDR"/>
+			<xs:enumeration value="BIZZ"/>
+			<xs:enumeration value="DLVY"/>
+			<xs:enumeration value="HOME"/>
+			<xs:enumeration value="MLTO"/>
+			<xs:enumeration value="PBOX"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="AddressType3Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="AddressType2Code"/>
+			<xs:element name="Prtry" type="GenericIdentification30"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="AmountType4Choice">
+		<xs:choice>
+			<xs:element name="InstdAmt" type="ActiveOrHistoricCurrencyAndAmount"/>
+			<xs:element name="EqvtAmt" type="EquivalentAmount2"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="AnyBICDec2014Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}([A-Z0-9]{3,3}){0,1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Authorisation1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="Authorisation1Code"/>
+			<xs:element name="Prtry" type="Max128Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="Authorisation1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AUTH"/>
+			<xs:enumeration value="FDET"/>
+			<xs:enumeration value="FSUM"/>
+			<xs:enumeration value="ILEV"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BaseOneRate">
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="11"/>
+			<xs:fractionDigits value="10"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="BatchBookingIndicator">
+		<xs:restriction base="xs:boolean"/>
+	</xs:simpleType>
+	<xs:simpleType name="BICFIDec2014Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}([A-Z0-9]{3,3}){0,1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification6">
+		<xs:sequence>
+			<xs:element name="FinInstnId" type="FinancialInstitutionIdentification18"/>
+			<xs:element name="BrnchId" type="BranchData3" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification6_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="BranchAndFinancialInstitutionIdentification6">
+				<xs:sequence>
+					<xs:element name="FinInstnId" type="FinancialInstitutionIdentification18_pain001_ch"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification6_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="BranchAndFinancialInstitutionIdentification6">
+				<xs:sequence>
+					<xs:element name="FinInstnId" type="FinancialInstitutionIdentification18_pain001_ch_2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification6_pain001_ch_3">
+		<xs:complexContent>
+			<xs:restriction base="BranchAndFinancialInstitutionIdentification6">
+				<xs:sequence>
+					<xs:element name="FinInstnId" type="FinancialInstitutionIdentification18_pain001_ch_3"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BranchAndFinancialInstitutionIdentification6_pain001_ch_4">
+		<xs:complexContent>
+			<xs:restriction base="BranchAndFinancialInstitutionIdentification6">
+				<xs:sequence>
+					<xs:element name="FinInstnId" type="FinancialInstitutionIdentification18_pain001_ch_4"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="BranchData3">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text" minOccurs="0"/>
+			<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="PostalAddress24" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CashAccount38">
+		<xs:sequence>
+			<xs:element name="Id" type="AccountIdentification4Choice"/>
+			<xs:element name="Tp" type="CashAccountType2Choice" minOccurs="0"/>
+			<xs:element name="Ccy" type="ActiveOrHistoricCurrencyCode" minOccurs="0"/>
+			<xs:element name="Nm" type="Max70Text" minOccurs="0"/>
+			<xs:element name="Prxy" type="ProxyAccountIdentification1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CashAccount38_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="CashAccount38">
+				<xs:sequence>
+					<xs:element name="Id" type="AccountIdentification4Choice_pain001_ch"/>
+					<xs:element name="Tp" type="CashAccountType2Choice" minOccurs="0"/>
+					<xs:element name="Ccy" type="ActiveOrHistoricCurrencyCode" minOccurs="0"/>
+					<xs:element name="Prxy" type="ProxyAccountIdentification1" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CashAccount38_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="CashAccount38">
+				<xs:sequence>
+					<xs:element name="Id" type="AccountIdentification4Choice_pain001_ch"/>
+					<xs:element name="Ccy" type="ActiveOrHistoricCurrencyCode" minOccurs="0"/>
+					<xs:element name="Prxy" type="ProxyAccountIdentification1" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CashAccount38_pain001_ch_3">
+		<xs:complexContent>
+			<xs:restriction base="CashAccount38">
+				<xs:sequence>
+					<xs:element name="Id" type="AccountIdentification4Choice"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CashAccount38_pain001_ch_4">
+		<xs:complexContent>
+			<xs:restriction base="CashAccount38">
+				<xs:sequence>
+					<xs:element name="Id" type="AccountIdentification4Choice_pain001_ch"/>
+					<xs:element name="Prxy" type="ProxyAccountIdentification1" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CashAccountType2Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalCashAccountType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CategoryPurpose1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalCategoryPurpose1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CategoryPurpose1Choice_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="CategoryPurpose1Choice">
+				<xs:choice>
+					<xs:element name="Cd" type="ExternalCategoryPurpose1Code"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="ChargeBearerType1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CRED"/>
+			<xs:enumeration value="DEBT"/>
+			<xs:enumeration value="SHAR"/>
+			<xs:enumeration value="SLEV"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Cheque11">
+		<xs:sequence>
+			<xs:element name="ChqTp" type="ChequeType2Code" minOccurs="0"/>
+			<xs:element name="ChqNb" type="Max35Text" minOccurs="0"/>
+			<xs:element name="ChqFr" type="NameAndAddress16" minOccurs="0"/>
+			<xs:element name="DlvryMtd" type="ChequeDeliveryMethod1Choice" minOccurs="0"/>
+			<xs:element name="DlvrTo" type="NameAndAddress16" minOccurs="0"/>
+			<xs:element name="InstrPrty" type="Priority2Code" minOccurs="0"/>
+			<xs:element name="ChqMtrtyDt" type="ISODate" minOccurs="0"/>
+			<xs:element name="FrmsCd" type="Max35Text" minOccurs="0"/>
+			<xs:element name="MemoFld" type="Max35Text" minOccurs="0" maxOccurs="2"/>
+			<xs:element name="RgnlClrZone" type="Max35Text" minOccurs="0"/>
+			<xs:element name="PrtLctn" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Sgntr" type="Max70Text" minOccurs="0" maxOccurs="5"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Cheque11_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Cheque11">
+				<xs:sequence>
+					<xs:element name="ChqTp" type="ChequeType2Code" minOccurs="0"/>
+					<xs:element name="DlvryMtd" type="ChequeDeliveryMethod1Choice" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="ChequeDelivery1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CRCD"/>
+			<xs:enumeration value="CRDB"/>
+			<xs:enumeration value="CRFA"/>
+			<xs:enumeration value="MLCD"/>
+			<xs:enumeration value="MLDB"/>
+			<xs:enumeration value="MLFA"/>
+			<xs:enumeration value="PUCD"/>
+			<xs:enumeration value="PUDB"/>
+			<xs:enumeration value="PUFA"/>
+			<xs:enumeration value="RGCD"/>
+			<xs:enumeration value="RGDB"/>
+			<xs:enumeration value="RGFA"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ChequeDeliveryMethod1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ChequeDelivery1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="ChequeType2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="BCHQ"/>
+			<xs:enumeration value="CCCH"/>
+			<xs:enumeration value="CCHQ"/>
+			<xs:enumeration value="DRFT"/>
+			<xs:enumeration value="ELDR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ClearingSystemIdentification2Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalClearingSystemIdentification1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ClearingSystemIdentification2Choice_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="ClearingSystemIdentification2Choice">
+				<xs:choice>
+					<xs:element name="Cd" type="ExternalClearingSystemIdentification1Code"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ClearingSystemMemberIdentification2">
+		<xs:sequence>
+			<xs:element name="ClrSysId" type="ClearingSystemIdentification2Choice" minOccurs="0"/>
+			<xs:element name="MmbId" type="Max35Text"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ClearingSystemMemberIdentification2_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="ClearingSystemMemberIdentification2">
+				<xs:sequence>
+					<xs:element name="ClrSysId" type="ClearingSystemIdentification2Choice_pain001_ch" minOccurs="0"/>
+					<xs:element name="MmbId" type="Max35Text"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Contact4">
+		<xs:sequence>
+			<xs:element name="NmPrfx" type="NamePrefix2Code" minOccurs="0"/>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="PhneNb" type="PhoneNumber" minOccurs="0"/>
+			<xs:element name="MobNb" type="PhoneNumber" minOccurs="0"/>
+			<xs:element name="FaxNb" type="PhoneNumber" minOccurs="0"/>
+			<xs:element name="EmailAdr" type="Max2048Text" minOccurs="0"/>
+			<xs:element name="EmailPurp" type="Max35Text" minOccurs="0"/>
+			<xs:element name="JobTitl" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Rspnsblty" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+			<xs:element name="Othr" type="OtherContact1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="PrefrdMtd" type="PreferredContactMethod1Code" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Contact4_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Contact4">
+				<xs:sequence>
+					<xs:element name="Othr" type="OtherContact1_pain001_ch" minOccurs="0" maxOccurs="4"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="CountryCode">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CreditDebitCode">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CRDT"/>
+			<xs:enumeration value="DBIT"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="CreditorReferenceInformation2">
+		<xs:sequence>
+			<xs:element name="Tp" type="CreditorReferenceType2" minOccurs="0"/>
+			<xs:element name="Ref" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="DocumentType3Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="CreditorReferenceType2">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="CreditorReferenceType1Choice"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditTransferTransaction34">
+		<xs:sequence>
+			<xs:element name="PmtId" type="PaymentIdentification6"/>
+			<xs:element name="PmtTpInf" type="PaymentTypeInformation26" minOccurs="0"/>
+			<xs:element name="Amt" type="AmountType4Choice"/>
+			<xs:element name="XchgRateInf" type="ExchangeRate1" minOccurs="0"/>
+			<xs:element name="ChrgBr" type="ChargeBearerType1Code" minOccurs="0"/>
+			<xs:element name="ChqInstr" type="Cheque11" minOccurs="0"/>
+			<xs:element name="UltmtDbtr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="IntrmyAgt1" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+			<xs:element name="IntrmyAgt1Acct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="IntrmyAgt2" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+			<xs:element name="IntrmyAgt2Acct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="IntrmyAgt3" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+			<xs:element name="IntrmyAgt3Acct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="CdtrAgt" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+			<xs:element name="CdtrAgtAcct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="Cdtr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="CdtrAcct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="UltmtCdtr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="InstrForCdtrAgt" type="InstructionForCreditorAgent1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="InstrForDbtrAgt" type="Max140Text" minOccurs="0"/>
+			<xs:element name="Purp" type="Purpose2Choice" minOccurs="0"/>
+			<xs:element name="RgltryRptg" type="RegulatoryReporting3" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="Tax" type="TaxInformation8" minOccurs="0"/>
+			<xs:element name="RltdRmtInf" type="RemittanceLocation7" minOccurs="0" maxOccurs="10"/>
+			<xs:element name="RmtInf" type="RemittanceInformation16" minOccurs="0"/>
+			<xs:element name="SplmtryData" type="SupplementaryData1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CreditTransferTransaction34_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="CreditTransferTransaction34">
+				<xs:sequence>
+					<xs:element name="PmtId" type="PaymentIdentification6_pain001_ch"/>
+					<xs:element name="PmtTpInf" type="PaymentTypeInformation26_pain001_ch_2" minOccurs="0"/>
+					<xs:element name="Amt" type="AmountType4Choice"/>
+					<xs:element name="XchgRateInf" type="ExchangeRate1" minOccurs="0"/>
+					<xs:element name="ChrgBr" type="ChargeBearerType1Code" minOccurs="0"/>
+					<xs:element name="ChqInstr" type="Cheque11_pain001_ch" minOccurs="0"/>
+					<xs:element name="UltmtDbtr" type="PartyIdentification135_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="IntrmyAgt1" type="BranchAndFinancialInstitutionIdentification6_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="IntrmyAgt1Acct" type="CashAccount38_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="CdtrAgt" type="BranchAndFinancialInstitutionIdentification6_pain001_ch_4" minOccurs="0"/>
+					<xs:element name="CdtrAgtAcct" type="CashAccount38_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="Cdtr" type="PartyIdentification135_pain001_ch_4" minOccurs="0"/>
+					<xs:element name="CdtrAcct" type="CashAccount38_pain001_ch_4" minOccurs="0"/>
+					<xs:element name="UltmtCdtr" type="PartyIdentification135_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="InstrForCdtrAgt" type="InstructionForCreditorAgent1" minOccurs="0" maxOccurs="2"/>
+					<xs:element name="InstrForDbtrAgt" type="Max140Text" minOccurs="0"/>
+					<xs:element name="Purp" type="Purpose2Choice_pain001_ch" minOccurs="0"/>
+					<xs:element name="RgltryRptg" type="RegulatoryReporting3" minOccurs="0" maxOccurs="10"/>
+					<xs:element name="RltdRmtInf" type="RemittanceLocation7" minOccurs="0"/>
+					<xs:element name="RmtInf" type="RemittanceInformation16_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CustomerCreditTransferInitiationV09">
+		<xs:sequence>
+			<xs:element name="GrpHdr" type="GroupHeader85"/>
+			<xs:element name="PmtInf" type="PaymentInstruction30" maxOccurs="unbounded"/>
+			<xs:element name="SplmtryData" type="SupplementaryData1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CustomerCreditTransferInitiationV09_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="CustomerCreditTransferInitiationV09">
+				<xs:sequence>
+					<xs:element name="GrpHdr" type="GroupHeader85_pain001_ch"/>
+					<xs:element name="PmtInf" type="PaymentInstruction30_pain001_ch" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="DateAndDateTime2Choice">
+		<xs:choice>
+			<xs:element name="Dt" type="ISODate"/>
+			<xs:element name="DtTm" type="ISODateTime"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="DateAndPlaceOfBirth1">
+		<xs:sequence>
+			<xs:element name="BirthDt" type="ISODate"/>
+			<xs:element name="PrvcOfBirth" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CityOfBirth" type="Max35Text"/>
+			<xs:element name="CtryOfBirth" type="CountryCode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DatePeriod2">
+		<xs:sequence>
+			<xs:element name="FrDt" type="ISODate"/>
+			<xs:element name="ToDt" type="ISODate"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="DecimalNumber">
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="17"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="DiscountAmountAndType1">
+		<xs:sequence>
+			<xs:element name="Tp" type="DiscountAmountType1Choice" minOccurs="0"/>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DiscountAmountType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalDiscountAmountType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Document">
+		<xs:sequence>
+			<xs:element name="CstmrCdtTrfInitn" type="CustomerCreditTransferInitiationV09"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentAdjustment1">
+		<xs:sequence>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+			<xs:element name="CdtDbtInd" type="CreditDebitCode" minOccurs="0"/>
+			<xs:element name="Rsn" type="Max4Text" minOccurs="0"/>
+			<xs:element name="AddtlInf" type="Max140Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentLineIdentification1">
+		<xs:sequence>
+			<xs:element name="Tp" type="DocumentLineType1" minOccurs="0"/>
+			<xs:element name="Nb" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RltdDt" type="ISODate" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentLineInformation1">
+		<xs:sequence>
+			<xs:element name="Id" type="DocumentLineIdentification1" maxOccurs="unbounded"/>
+			<xs:element name="Desc" type="Max2048Text" minOccurs="0"/>
+			<xs:element name="Amt" type="RemittanceAmount3" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentLineType1">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="DocumentLineType1Choice"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="DocumentLineType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalDocumentLineType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="DocumentType3Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DISP"/>
+			<xs:enumeration value="FXDR"/>
+			<xs:enumeration value="PUOR"/>
+			<xs:enumeration value="RADM"/>
+			<xs:enumeration value="RPIN"/>
+			<xs:enumeration value="SCOR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocumentType6Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AROI"/>
+			<xs:enumeration value="BOLD"/>
+			<xs:enumeration value="CINV"/>
+			<xs:enumeration value="CMCN"/>
+			<xs:enumeration value="CNFA"/>
+			<xs:enumeration value="CREN"/>
+			<xs:enumeration value="DEBN"/>
+			<xs:enumeration value="DISP"/>
+			<xs:enumeration value="DNFA"/>
+			<xs:enumeration value="HIRI"/>
+			<xs:enumeration value="MSIN"/>
+			<xs:enumeration value="PUOR"/>
+			<xs:enumeration value="SBIN"/>
+			<xs:enumeration value="SOAC"/>
+			<xs:enumeration value="TSUT"/>
+			<xs:enumeration value="VCHR"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Document_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Document">
+				<xs:sequence>
+					<xs:element name="CstmrCdtTrfInitn" type="CustomerCreditTransferInitiationV09_pain001_ch"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="EquivalentAmount2">
+		<xs:sequence>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+			<xs:element name="CcyOfTrf" type="ActiveOrHistoricCurrencyCode"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="Exact4AlphaNumericText">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[a-zA-Z0-9]{4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ExchangeRate1">
+		<xs:sequence>
+			<xs:element name="UnitCcy" type="ActiveOrHistoricCurrencyCode" minOccurs="0"/>
+			<xs:element name="XchgRate" type="BaseOneRate" minOccurs="0"/>
+			<xs:element name="RateTp" type="ExchangeRateType1Code" minOccurs="0"/>
+			<xs:element name="CtrctId" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="ExchangeRateType1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AGRD"/>
+			<xs:enumeration value="SALE"/>
+			<xs:enumeration value="SPOT"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalAccountIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalCashAccountType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalCategoryPurpose1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalClearingSystemIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="5"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalDiscountAmountType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalDocumentLineType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalFinancialInstitutionIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalGarnishmentType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalLocalInstrument1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalOrganisationIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalPersonIdentification1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalProxyAccountType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalPurpose1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalServiceLevel1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ExternalTaxAmountType1Code">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="FinancialIdentificationSchemeName1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalFinancialInstitutionIdentification1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification18">
+		<xs:sequence>
+			<xs:element name="BICFI" type="BICFIDec2014Identifier" minOccurs="0"/>
+			<xs:element name="ClrSysMmbId" type="ClearingSystemMemberIdentification2" minOccurs="0"/>
+			<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="PostalAddress24" minOccurs="0"/>
+			<xs:element name="Othr" type="GenericFinancialIdentification1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification18_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="FinancialInstitutionIdentification18">
+				<xs:sequence>
+					<xs:element name="BICFI" type="BICFIDec2014Identifier" minOccurs="0"/>
+					<xs:element name="ClrSysMmbId" type="ClearingSystemMemberIdentification2" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericFinancialIdentification1_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification18_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="FinancialInstitutionIdentification18">
+				<xs:sequence>
+					<xs:element name="BICFI" type="BICFIDec2014Identifier" minOccurs="0"/>
+					<xs:element name="ClrSysMmbId" type="ClearingSystemMemberIdentification2_pain001_ch" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification18_pain001_ch_3">
+		<xs:complexContent>
+			<xs:restriction base="FinancialInstitutionIdentification18">
+				<xs:sequence>
+					<xs:element name="BICFI" type="BICFIDec2014Identifier" minOccurs="0"/>
+					<xs:element name="ClrSysMmbId" type="ClearingSystemMemberIdentification2_pain001_ch" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_4" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="FinancialInstitutionIdentification18_pain001_ch_4">
+		<xs:complexContent>
+			<xs:restriction base="FinancialInstitutionIdentification18">
+				<xs:sequence>
+					<xs:element name="BICFI" type="BICFIDec2014Identifier" minOccurs="0"/>
+					<xs:element name="ClrSysMmbId" type="ClearingSystemMemberIdentification2_pain001_ch" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericFinancialIdentification1_pain001_ch_2" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Garnishment3">
+		<xs:sequence>
+			<xs:element name="Tp" type="GarnishmentType1"/>
+			<xs:element name="Grnshee" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="GrnshmtAdmstr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="RefNb" type="Max140Text" minOccurs="0"/>
+			<xs:element name="Dt" type="ISODate" minOccurs="0"/>
+			<xs:element name="RmtdAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="FmlyMdclInsrncInd" type="TrueFalseIndicator" minOccurs="0"/>
+			<xs:element name="MplyeeTermntnInd" type="TrueFalseIndicator" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Garnishment3_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Garnishment3">
+				<xs:sequence>
+					<xs:element name="Tp" type="GarnishmentType1"/>
+					<xs:element name="Grnshee" type="PartyIdentification135_pain001_ch_5" minOccurs="0"/>
+					<xs:element name="GrnshmtAdmstr" type="PartyIdentification135_pain001_ch_5" minOccurs="0"/>
+					<xs:element name="RefNb" type="Max140Text" minOccurs="0"/>
+					<xs:element name="Dt" type="ISODate" minOccurs="0"/>
+					<xs:element name="RmtdAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+					<xs:element name="FmlyMdclInsrncInd" type="TrueFalseIndicator" minOccurs="0"/>
+					<xs:element name="MplyeeTermntnInd" type="TrueFalseIndicator" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GarnishmentType1">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="GarnishmentType1Choice"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GarnishmentType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalGarnishmentType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="GenericAccountIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max34Text"/>
+			<xs:element name="SchmeNm" type="AccountSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericAccountIdentification1_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="GenericAccountIdentification1">
+				<xs:sequence>
+					<xs:element name="Id" type="Max34Text"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GenericFinancialIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="FinancialIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericFinancialIdentification1_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="GenericFinancialIdentification1">
+				<xs:sequence>
+					<xs:element name="Id" type="Max35Text"/>
+					<xs:element name="SchmeNm" type="FinancialIdentificationSchemeName1Choice" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GenericFinancialIdentification1_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="GenericFinancialIdentification1">
+				<xs:sequence>
+					<xs:element name="Id" type="Max35Text"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="GenericIdentification30">
+		<xs:sequence>
+			<xs:element name="Id" type="Exact4AlphaNumericText"/>
+			<xs:element name="Issr" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericOrganisationIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="OrganisationIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GenericPersonIdentification1">
+		<xs:sequence>
+			<xs:element name="Id" type="Max35Text"/>
+			<xs:element name="SchmeNm" type="PersonIdentificationSchemeName1Choice" minOccurs="0"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GroupHeader85">
+		<xs:sequence>
+			<xs:element name="MsgId" type="Max35Text"/>
+			<xs:element name="CreDtTm" type="ISODateTime"/>
+			<xs:element name="Authstn" type="Authorisation1Choice" minOccurs="0" maxOccurs="2"/>
+			<xs:element name="NbOfTxs" type="Max15NumericText"/>
+			<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+			<xs:element name="InitgPty" type="PartyIdentification135"/>
+			<xs:element name="FwdgAgt" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="GroupHeader85_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="GroupHeader85">
+				<xs:sequence>
+					<xs:element name="MsgId" type="Max35Text_pain001_ch"/>
+					<xs:element name="CreDtTm" type="ISODateTime"/>
+					<xs:element name="NbOfTxs" type="Max15NumericText"/>
+					<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+					<xs:element name="InitgPty" type="PartyIdentification135_pain001_ch"/>
+					<xs:element name="FwdgAgt" type="BranchAndFinancialInstitutionIdentification6_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="IBAN2007Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Instruction3Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CHQB"/>
+			<xs:enumeration value="HOLD"/>
+			<xs:enumeration value="PHOB"/>
+			<xs:enumeration value="TELB"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="InstructionForCreditorAgent1">
+		<xs:sequence>
+			<xs:element name="Cd" type="Instruction3Code" minOccurs="0"/>
+			<xs:element name="InstrInf" type="Max140Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="ISODate">
+		<xs:restriction base="xs:date"/>
+	</xs:simpleType>
+	<xs:simpleType name="ISODateTime">
+		<xs:restriction base="xs:dateTime"/>
+	</xs:simpleType>
+	<xs:simpleType name="LEIIdentifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Z0-9]{18,18}[0-9]{2,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="LocalInstrument2Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalLocalInstrument1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="Max10Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="10"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max128Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="128"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max140Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="140"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max15NumericText">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{1,15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max16Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="16"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max2048Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="2048"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max34Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="34"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max350Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="350"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max35Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max35Text_pain001_ch">
+		<xs:restriction base="Max35Text">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="35"/>
+			<xs:pattern value="([A-Za-z0-9]|[+|\?|/|\-|:|\(|\)|\.|,|&apos;|\p{Zs}])*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max4Text">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Max70Text">
+		<xs:restriction base="SPSText">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="70"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="NameAndAddress16">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max140Text"/>
+			<xs:element name="Adr" type="PostalAddress24"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="NamePrefix2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="DOCT"/>
+			<xs:enumeration value="MADM"/>
+			<xs:enumeration value="MIKS"/>
+			<xs:enumeration value="MISS"/>
+			<xs:enumeration value="MIST"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Number">
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="OrganisationIdentification29">
+		<xs:sequence>
+			<xs:element name="AnyBIC" type="AnyBICDec2014Identifier" minOccurs="0"/>
+			<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+			<xs:element name="Othr" type="GenericOrganisationIdentification1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OrganisationIdentification29_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="OrganisationIdentification29">
+				<xs:sequence>
+					<xs:element name="AnyBIC" type="AnyBICDec2014Identifier" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericOrganisationIdentification1" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OrganisationIdentification29_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="OrganisationIdentification29">
+				<xs:sequence>
+					<xs:element name="AnyBIC" type="AnyBICDec2014Identifier" minOccurs="0"/>
+					<xs:element name="LEI" type="LEIIdentifier" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericOrganisationIdentification1" minOccurs="0" maxOccurs="2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="OrganisationIdentificationSchemeName1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalOrganisationIdentification1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="OtherContact1">
+		<xs:sequence>
+			<xs:element name="ChanlTp" type="Max4Text"/>
+			<xs:element name="Id" type="Max128Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="OtherContact1_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="OtherContact1">
+				<xs:sequence>
+					<xs:element name="ChanlTp" type="Max4Text"/>
+					<xs:element name="Id" type="Max128Text"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Party38Choice">
+		<xs:choice>
+			<xs:element name="OrgId" type="OrganisationIdentification29"/>
+			<xs:element name="PrvtId" type="PersonIdentification13"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Party38Choice_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Party38Choice">
+				<xs:choice>
+					<xs:element name="OrgId" type="OrganisationIdentification29_pain001_ch"/>
+					<xs:element name="PrvtId" type="PersonIdentification13_pain001_ch"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="Party38Choice_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="Party38Choice">
+				<xs:choice>
+					<xs:element name="OrgId" type="OrganisationIdentification29_pain001_ch_2"/>
+					<xs:element name="PrvtId" type="PersonIdentification13_pain001_ch_2"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="PostalAddress24" minOccurs="0"/>
+			<xs:element name="Id" type="Party38Choice" minOccurs="0"/>
+			<xs:element name="CtryOfRes" type="CountryCode" minOccurs="0"/>
+			<xs:element name="CtctDtls" type="Contact4" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PartyIdentification135">
+				<xs:sequence>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="Id" type="Party38Choice_pain001_ch" minOccurs="0"/>
+					<xs:element name="CtctDtls" type="Contact4_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="PartyIdentification135">
+				<xs:sequence>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_2" minOccurs="0"/>
+					<xs:element name="Id" type="Party38Choice_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135_pain001_ch_3">
+		<xs:complexContent>
+			<xs:restriction base="PartyIdentification135">
+				<xs:sequence>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="Id" type="Party38Choice_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135_pain001_ch_4">
+		<xs:complexContent>
+			<xs:restriction base="PartyIdentification135">
+				<xs:sequence>
+					<xs:element name="Nm" type="Max140Text"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="Id" type="Party38Choice_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PartyIdentification135_pain001_ch_5">
+		<xs:complexContent>
+			<xs:restriction base="PartyIdentification135">
+				<xs:sequence>
+					<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+					<xs:element name="PstlAdr" type="PostalAddress24_pain001_ch_5" minOccurs="0"/>
+					<xs:element name="Id" type="Party38Choice_pain001_ch_2" minOccurs="0"/>
+					<xs:element name="CtryOfRes" type="CountryCode" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PaymentIdentification6">
+		<xs:sequence>
+			<xs:element name="InstrId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="EndToEndId" type="Max35Text"/>
+			<xs:element name="UETR" type="UUIDv4Identifier" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentIdentification6_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PaymentIdentification6">
+				<xs:sequence>
+					<xs:element name="InstrId" type="Max35Text_pain001_ch" minOccurs="0"/>
+					<xs:element name="EndToEndId" type="Max35Text_pain001_ch"/>
+					<xs:element name="UETR" type="UUIDv4Identifier" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PaymentInstruction30">
+		<xs:sequence>
+			<xs:element name="PmtInfId" type="Max35Text"/>
+			<xs:element name="PmtMtd" type="PaymentMethod3Code"/>
+			<xs:element name="BtchBookg" type="BatchBookingIndicator" minOccurs="0"/>
+			<xs:element name="NbOfTxs" type="Max15NumericText" minOccurs="0"/>
+			<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+			<xs:element name="PmtTpInf" type="PaymentTypeInformation26" minOccurs="0"/>
+			<xs:element name="ReqdExctnDt" type="DateAndDateTime2Choice"/>
+			<xs:element name="PoolgAdjstmntDt" type="ISODate" minOccurs="0"/>
+			<xs:element name="Dbtr" type="PartyIdentification135"/>
+			<xs:element name="DbtrAcct" type="CashAccount38"/>
+			<xs:element name="DbtrAgt" type="BranchAndFinancialInstitutionIdentification6"/>
+			<xs:element name="DbtrAgtAcct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="InstrForDbtrAgt" type="Max140Text" minOccurs="0"/>
+			<xs:element name="UltmtDbtr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="ChrgBr" type="ChargeBearerType1Code" minOccurs="0"/>
+			<xs:element name="ChrgsAcct" type="CashAccount38" minOccurs="0"/>
+			<xs:element name="ChrgsAcctAgt" type="BranchAndFinancialInstitutionIdentification6" minOccurs="0"/>
+			<xs:element name="CdtTrfTxInf" type="CreditTransferTransaction34" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentInstruction30_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PaymentInstruction30">
+				<xs:sequence>
+					<xs:element name="PmtInfId" type="Max35Text_pain001_ch"/>
+					<xs:element name="PmtMtd" type="PaymentMethod3Code"/>
+					<xs:element name="BtchBookg" type="BatchBookingIndicator" minOccurs="0"/>
+					<xs:element name="NbOfTxs" type="Max15NumericText" minOccurs="0"/>
+					<xs:element name="CtrlSum" type="DecimalNumber" minOccurs="0"/>
+					<xs:element name="PmtTpInf" type="PaymentTypeInformation26_pain001_ch" minOccurs="0"/>
+					<xs:element name="ReqdExctnDt" type="DateAndDateTime2Choice"/>
+					<xs:element name="Dbtr" type="PartyIdentification135_pain001_ch_2"/>
+					<xs:element name="DbtrAcct" type="CashAccount38_pain001_ch"/>
+					<xs:element name="DbtrAgt" type="BranchAndFinancialInstitutionIdentification6_pain001_ch_2"/>
+					<xs:element name="InstrForDbtrAgt" type="Max140Text" minOccurs="0"/>
+					<xs:element name="UltmtDbtr" type="PartyIdentification135_pain001_ch_3" minOccurs="0"/>
+					<xs:element name="ChrgBr" type="ChargeBearerType1Code" minOccurs="0"/>
+					<xs:element name="ChrgsAcct" type="CashAccount38_pain001_ch_2" minOccurs="0"/>
+					<xs:element name="CdtTrfTxInf" type="CreditTransferTransaction34_pain001_ch" maxOccurs="unbounded"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="PaymentMethod3Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CHK"/>
+			<xs:enumeration value="TRA"/>
+			<xs:enumeration value="TRF"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PaymentTypeInformation26">
+		<xs:sequence>
+			<xs:element name="InstrPrty" type="Priority2Code" minOccurs="0"/>
+			<xs:element name="SvcLvl" type="ServiceLevel8Choice" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="LclInstrm" type="LocalInstrument2Choice" minOccurs="0"/>
+			<xs:element name="CtgyPurp" type="CategoryPurpose1Choice" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PaymentTypeInformation26_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PaymentTypeInformation26">
+				<xs:sequence>
+					<xs:element name="InstrPrty" type="Priority2Code" minOccurs="0"/>
+					<xs:element name="SvcLvl" type="ServiceLevel8Choice" minOccurs="0" maxOccurs="3"/>
+					<xs:element name="LclInstrm" type="LocalInstrument2Choice" minOccurs="0"/>
+					<xs:element name="CtgyPurp" type="CategoryPurpose1Choice_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PaymentTypeInformation26_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="PaymentTypeInformation26">
+				<xs:sequence>
+					<xs:element name="InstrPrty" type="Priority2Code" minOccurs="0"/>
+					<xs:element name="SvcLvl" type="ServiceLevel8Choice" minOccurs="0" maxOccurs="3"/>
+					<xs:element name="LclInstrm" type="LocalInstrument2Choice" minOccurs="0"/>
+					<xs:element name="CtgyPurp" type="CategoryPurpose1Choice" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="PercentageRate">
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="11"/>
+			<xs:fractionDigits value="10"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PersonIdentification13">
+		<xs:sequence>
+			<xs:element name="DtAndPlcOfBirth" type="DateAndPlaceOfBirth1" minOccurs="0"/>
+			<xs:element name="Othr" type="GenericPersonIdentification1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentification13_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PersonIdentification13">
+				<xs:sequence>
+					<xs:element name="DtAndPlcOfBirth" type="DateAndPlaceOfBirth1" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericPersonIdentification1" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentification13_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="PersonIdentification13">
+				<xs:sequence>
+					<xs:element name="DtAndPlcOfBirth" type="DateAndPlaceOfBirth1" minOccurs="0"/>
+					<xs:element name="Othr" type="GenericPersonIdentification1" minOccurs="0" maxOccurs="2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PersonIdentificationSchemeName1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalPersonIdentification1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="PhoneNumber">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="\+[0-9]{1,3}-[0-9()+\-]{1,30}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="PostalAddress24">
+		<xs:sequence>
+			<xs:element name="AdrTp" type="AddressType3Choice" minOccurs="0"/>
+			<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+			<xs:element name="SubDept" type="Max70Text" minOccurs="0"/>
+			<xs:element name="StrtNm" type="Max70Text" minOccurs="0"/>
+			<xs:element name="BldgNb" type="Max16Text" minOccurs="0"/>
+			<xs:element name="BldgNm" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Flr" type="Max70Text" minOccurs="0"/>
+			<xs:element name="PstBx" type="Max16Text" minOccurs="0"/>
+			<xs:element name="Room" type="Max70Text" minOccurs="0"/>
+			<xs:element name="PstCd" type="Max16Text" minOccurs="0"/>
+			<xs:element name="TwnNm" type="Max35Text" minOccurs="0"/>
+			<xs:element name="TwnLctnNm" type="Max35Text" minOccurs="0"/>
+			<xs:element name="DstrctNm" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CtrySubDvsn" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+			<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="7"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PostalAddress24_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="PostalAddress24">
+				<xs:sequence>
+					<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="7"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PostalAddress24_pain001_ch_2">
+		<xs:complexContent>
+			<xs:restriction base="PostalAddress24">
+				<xs:sequence>
+					<xs:element name="AdrTp" type="AddressType3Choice" minOccurs="0"/>
+					<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="SubDept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="StrtNm" type="Max70Text" minOccurs="0"/>
+					<xs:element name="BldgNb" type="Max16Text" minOccurs="0"/>
+					<xs:element name="BldgNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Flr" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstBx" type="Max16Text" minOccurs="0"/>
+					<xs:element name="Room" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstCd" type="Max16Text" minOccurs="0"/>
+					<xs:element name="TwnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="TwnLctnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="DstrctNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="CtrySubDvsn" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+					<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PostalAddress24_pain001_ch_3">
+		<xs:complexContent>
+			<xs:restriction base="PostalAddress24">
+				<xs:sequence>
+					<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="SubDept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="StrtNm" type="Max70Text" minOccurs="0"/>
+					<xs:element name="BldgNb" type="Max16Text" minOccurs="0"/>
+					<xs:element name="BldgNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Flr" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstBx" type="Max16Text" minOccurs="0"/>
+					<xs:element name="Room" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstCd" type="Max16Text" minOccurs="0"/>
+					<xs:element name="TwnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="TwnLctnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="DstrctNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="CtrySubDvsn" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+					<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PostalAddress24_pain001_ch_4">
+		<xs:complexContent>
+			<xs:restriction base="PostalAddress24">
+				<xs:sequence>
+					<xs:element name="AdrLine" type="Max70Text" minOccurs="0" maxOccurs="2"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="PostalAddress24_pain001_ch_5">
+		<xs:complexContent>
+			<xs:restriction base="PostalAddress24">
+				<xs:sequence>
+					<xs:element name="Dept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="SubDept" type="Max70Text" minOccurs="0"/>
+					<xs:element name="StrtNm" type="Max70Text" minOccurs="0"/>
+					<xs:element name="BldgNb" type="Max16Text" minOccurs="0"/>
+					<xs:element name="BldgNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Flr" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstBx" type="Max16Text" minOccurs="0"/>
+					<xs:element name="Room" type="Max70Text" minOccurs="0"/>
+					<xs:element name="PstCd" type="Max16Text" minOccurs="0"/>
+					<xs:element name="TwnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="TwnLctnNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="DstrctNm" type="Max35Text" minOccurs="0"/>
+					<xs:element name="CtrySubDvsn" type="Max35Text" minOccurs="0"/>
+					<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="PreferredContactMethod1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CELL"/>
+			<xs:enumeration value="FAXX"/>
+			<xs:enumeration value="LETT"/>
+			<xs:enumeration value="MAIL"/>
+			<xs:enumeration value="PHON"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Priority2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="HIGH"/>
+			<xs:enumeration value="NORM"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ProxyAccountIdentification1">
+		<xs:sequence>
+			<xs:element name="Tp" type="ProxyAccountType1Choice" minOccurs="0"/>
+			<xs:element name="Id" type="Max2048Text"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ProxyAccountType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalProxyAccountType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Purpose2Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalPurpose1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="Purpose2Choice_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="Purpose2Choice">
+				<xs:choice>
+					<xs:element name="Cd" type="ExternalPurpose1Code"/>
+				</xs:choice>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="ReferredDocumentInformation7">
+		<xs:sequence>
+			<xs:element name="Tp" type="ReferredDocumentType4" minOccurs="0"/>
+			<xs:element name="Nb" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RltdDt" type="ISODate" minOccurs="0"/>
+			<xs:element name="LineDtls" type="DocumentLineInformation1" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ReferredDocumentType3Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="DocumentType6Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="ReferredDocumentType4">
+		<xs:sequence>
+			<xs:element name="CdOrPrtry" type="ReferredDocumentType3Choice"/>
+			<xs:element name="Issr" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RegulatoryAuthority2">
+		<xs:sequence>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+			<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RegulatoryReporting3">
+		<xs:sequence>
+			<xs:element name="DbtCdtRptgInd" type="RegulatoryReportingType1Code" minOccurs="0"/>
+			<xs:element name="Authrty" type="RegulatoryAuthority2" minOccurs="0"/>
+			<xs:element name="Dtls" type="StructuredRegulatoryReporting3" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="RegulatoryReportingType1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="BOTH"/>
+			<xs:enumeration value="CRED"/>
+			<xs:enumeration value="DEBT"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="RemittanceAmount2">
+		<xs:sequence>
+			<xs:element name="DuePyblAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="DscntApldAmt" type="DiscountAmountAndType1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CdtNoteAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TaxAmt" type="TaxAmountAndType1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AdjstmntAmtAndRsn" type="DocumentAdjustment1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="RmtdAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceAmount3">
+		<xs:sequence>
+			<xs:element name="DuePyblAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="DscntApldAmt" type="DiscountAmountAndType1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="CdtNoteAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TaxAmt" type="TaxAmountAndType1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="AdjstmntAmtAndRsn" type="DocumentAdjustment1" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="RmtdAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceInformation16">
+		<xs:sequence>
+			<xs:element name="Ustrd" type="Max140Text" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="Strd" type="StructuredRemittanceInformation16" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceInformation16_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="RemittanceInformation16">
+				<xs:sequence>
+					<xs:element name="Ustrd" type="Max140Text" minOccurs="0"/>
+					<xs:element name="Strd" type="StructuredRemittanceInformation16_pain001_ch" minOccurs="0"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="RemittanceLocation7">
+		<xs:sequence>
+			<xs:element name="RmtId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RmtLctnDtls" type="RemittanceLocationData1" minOccurs="0" maxOccurs="2"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RemittanceLocationData1">
+		<xs:sequence>
+			<xs:element name="Mtd" type="RemittanceLocationMethod2Code"/>
+			<xs:element name="ElctrncAdr" type="Max2048Text" minOccurs="0"/>
+			<xs:element name="PstlAdr" type="NameAndAddress16" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="RemittanceLocationMethod2Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EDIC"/>
+			<xs:enumeration value="EMAL"/>
+			<xs:enumeration value="FAXI"/>
+			<xs:enumeration value="POST"/>
+			<xs:enumeration value="SMSM"/>
+			<xs:enumeration value="URID"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="ServiceLevel8Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalServiceLevel1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:simpleType name="SPSText">
+		<xs:restriction base="xs:string">
+<!-- Fix to permit PHP schema validation -->
+<!--			<xs:pattern value="[\p{IsBasicLatin}\p{IsLatin-1Supplement}\p{IsLatinExtended-A}€ȘșȚț-[\p{C}]]+"/>-->
+			<xs:pattern value="[\p{IsBasicLatin}\p{IsLatin-1Supplement}\p{IsLatinExtended-A}-\p{C}€ȘșȚț]+"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="StructuredRegulatoryReporting3">
+		<xs:sequence>
+			<xs:element name="Tp" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Dt" type="ISODate" minOccurs="0"/>
+			<xs:element name="Ctry" type="CountryCode" minOccurs="0"/>
+			<xs:element name="Cd" type="Max10Text" minOccurs="0"/>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="Inf" type="Max35Text" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructuredRemittanceInformation16">
+		<xs:sequence>
+			<xs:element name="RfrdDocInf" type="ReferredDocumentInformation7" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="RfrdDocAmt" type="RemittanceAmount2" minOccurs="0"/>
+			<xs:element name="CdtrRefInf" type="CreditorReferenceInformation2" minOccurs="0"/>
+			<xs:element name="Invcr" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="Invcee" type="PartyIdentification135" minOccurs="0"/>
+			<xs:element name="TaxRmt" type="TaxInformation7" minOccurs="0"/>
+			<xs:element name="GrnshmtRmt" type="Garnishment3" minOccurs="0"/>
+			<xs:element name="AddtlRmtInf" type="Max140Text" minOccurs="0" maxOccurs="3"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="StructuredRemittanceInformation16_pain001_ch">
+		<xs:complexContent>
+			<xs:restriction base="StructuredRemittanceInformation16">
+				<xs:sequence>
+					<xs:element name="RfrdDocInf" type="ReferredDocumentInformation7" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="RfrdDocAmt" type="RemittanceAmount2" minOccurs="0"/>
+					<xs:element name="CdtrRefInf" type="CreditorReferenceInformation2" minOccurs="0"/>
+					<xs:element name="Invcr" type="PartyIdentification135_pain001_ch_5" minOccurs="0"/>
+					<xs:element name="Invcee" type="PartyIdentification135_pain001_ch_5" minOccurs="0"/>
+					<xs:element name="TaxRmt" type="TaxInformation7" minOccurs="0"/>
+					<xs:element name="GrnshmtRmt" type="Garnishment3_pain001_ch" minOccurs="0"/>
+					<xs:element name="AddtlRmtInf" type="Max140Text" minOccurs="0" maxOccurs="3"/>
+				</xs:sequence>
+			</xs:restriction>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="SupplementaryData1">
+		<xs:sequence>
+			<xs:element name="PlcAndNm" type="Max350Text" minOccurs="0"/>
+			<xs:element name="Envlp" type="SupplementaryDataEnvelope1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="SupplementaryDataEnvelope1">
+		<xs:sequence>
+			<xs:any namespace="##any" processContents="lax"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxAmount2">
+		<xs:sequence>
+			<xs:element name="Rate" type="PercentageRate" minOccurs="0"/>
+			<xs:element name="TaxblBaseAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TtlAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="Dtls" type="TaxRecordDetails2" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxAmountAndType1">
+		<xs:sequence>
+			<xs:element name="Tp" type="TaxAmountType1Choice" minOccurs="0"/>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxAmountType1Choice">
+		<xs:choice>
+			<xs:element name="Cd" type="ExternalTaxAmountType1Code"/>
+			<xs:element name="Prtry" type="Max35Text"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="TaxAuthorisation1">
+		<xs:sequence>
+			<xs:element name="Titl" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Nm" type="Max140Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxInformation7">
+		<xs:sequence>
+			<xs:element name="Cdtr" type="TaxParty1" minOccurs="0"/>
+			<xs:element name="Dbtr" type="TaxParty2" minOccurs="0"/>
+			<xs:element name="UltmtDbtr" type="TaxParty2" minOccurs="0"/>
+			<xs:element name="AdmstnZone" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RefNb" type="Max140Text" minOccurs="0"/>
+			<xs:element name="Mtd" type="Max35Text" minOccurs="0"/>
+			<xs:element name="TtlTaxblBaseAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TtlTaxAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="Dt" type="ISODate" minOccurs="0"/>
+			<xs:element name="SeqNb" type="Number" minOccurs="0"/>
+			<xs:element name="Rcrd" type="TaxRecord2" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxInformation8">
+		<xs:sequence>
+			<xs:element name="Cdtr" type="TaxParty1" minOccurs="0"/>
+			<xs:element name="Dbtr" type="TaxParty2" minOccurs="0"/>
+			<xs:element name="AdmstnZone" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RefNb" type="Max140Text" minOccurs="0"/>
+			<xs:element name="Mtd" type="Max35Text" minOccurs="0"/>
+			<xs:element name="TtlTaxblBaseAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="TtlTaxAmt" type="ActiveOrHistoricCurrencyAndAmount" minOccurs="0"/>
+			<xs:element name="Dt" type="ISODate" minOccurs="0"/>
+			<xs:element name="SeqNb" type="Number" minOccurs="0"/>
+			<xs:element name="Rcrd" type="TaxRecord2" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxParty1">
+		<xs:sequence>
+			<xs:element name="TaxId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RegnId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="TaxTp" type="Max35Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxParty2">
+		<xs:sequence>
+			<xs:element name="TaxId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="RegnId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="TaxTp" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Authstn" type="TaxAuthorisation1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxPeriod2">
+		<xs:sequence>
+			<xs:element name="Yr" type="ISODate" minOccurs="0"/>
+			<xs:element name="Tp" type="TaxRecordPeriod1Code" minOccurs="0"/>
+			<xs:element name="FrToDt" type="DatePeriod2" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxRecord2">
+		<xs:sequence>
+			<xs:element name="Tp" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Ctgy" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CtgyDtls" type="Max35Text" minOccurs="0"/>
+			<xs:element name="DbtrSts" type="Max35Text" minOccurs="0"/>
+			<xs:element name="CertId" type="Max35Text" minOccurs="0"/>
+			<xs:element name="FrmsCd" type="Max35Text" minOccurs="0"/>
+			<xs:element name="Prd" type="TaxPeriod2" minOccurs="0"/>
+			<xs:element name="TaxAmt" type="TaxAmount2" minOccurs="0"/>
+			<xs:element name="AddtlInf" type="Max140Text" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TaxRecordDetails2">
+		<xs:sequence>
+			<xs:element name="Prd" type="TaxPeriod2" minOccurs="0"/>
+			<xs:element name="Amt" type="ActiveOrHistoricCurrencyAndAmount"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="TaxRecordPeriod1Code">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="HLF1"/>
+			<xs:enumeration value="HLF2"/>
+			<xs:enumeration value="MM01"/>
+			<xs:enumeration value="MM02"/>
+			<xs:enumeration value="MM03"/>
+			<xs:enumeration value="MM04"/>
+			<xs:enumeration value="MM05"/>
+			<xs:enumeration value="MM06"/>
+			<xs:enumeration value="MM07"/>
+			<xs:enumeration value="MM08"/>
+			<xs:enumeration value="MM09"/>
+			<xs:enumeration value="MM10"/>
+			<xs:enumeration value="MM11"/>
+			<xs:enumeration value="MM12"/>
+			<xs:enumeration value="QTR1"/>
+			<xs:enumeration value="QTR2"/>
+			<xs:enumeration value="QTR3"/>
+			<xs:enumeration value="QTR4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TrueFalseIndicator">
+		<xs:restriction base="xs:boolean"/>
+	</xs:simpleType>
+	<xs:simpleType name="UUIDv4Identifier">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
This PR supports SPS-2022 specifications, issue https://github.com/ch2877/swiss-payment/issues/10 

[Delta guide](https://www.six-group.com/dam/download/banking-services/standardization/sps/ig-credit-transfer-delta-guide-sps2022-en.pdf) 
[Specifications](https://www.six-group.com/dam/download/banking-services/standardization/sps/ig-credit-transfer-sps2022-en.pdf)

As I have been dealing with several banks for years, I know that there will be a complex transition during 2024 between banks that only accept SPS-2021 files, or only SPS-2022 files, or both. Some banks still provide V11 files instead of CAMT.054 files, for example. I therefore decided to support both formats via the `CustomerCreditTransfer` constructor parameter, for reasons of flexibility and backwards compatibility.

Changes summary for SPS-2022:

- Schema name and location
- Element name changed from `BIC` → `BICFI`
- Element `ReqdExctnDt `must have `Dt` wrapper for dates
- Texts support new chars `€ȘșȚț`
- New `CtctDtls` elements
- Exclude transaction types for local instruments CH01, CH02 and CH03
- Adapt tests

There's a real problem with the file `pain.001.001.09.ch.03.xsd` on line 1556 with the new RegEx which validates text characters. PHP libxml throw a formatting rules error. After some tests, it works if the lasts rules are inversed.

Official : `<xs:pattern value="[\p{IsBasicLatin}\p{IsLatin-1Supplement}\p{IsLatinExtended-A}€ȘșȚț-[\p{C}]]+"/>`
Fixed : `<xs:pattern value="[\p{IsBasicLatin}\p{IsLatin-1Supplement}\p{IsLatinExtended-A}-\p{C}€ȘșȚț]+"/>`

Currently, the file `pain.001.001.09.ch.03.xsd` contains the fixed pattern. I have contacted SIX to see if it is possible to change this rule. I will post an update here.
